### PR TITLE
Fix typo AltSnap.dni after #533

### DIFF
--- a/AltSnap.dni
+++ b/AltSnap.dni
@@ -294,7 +294,7 @@ MMB=Menu
 ; exename, == exename:*|*,
 ; title|class, == *:title|class,
 
-Processes=StartMenuExperienceHost.exe,SearchApp.exe,mstsc.exe,msrdc.exe,osk.exe,Virtual PC.exe,LeageClient.exe,LeageClientUx.exe,LeageClientUxRender.exe
+Processes=StartMenuExperienceHost.exe,SearchApp.exe,mstsc.exe,msrdc.exe,osk.exe,Virtual PC.exe,LeagueClient.exe,LeagueClientUx.exe,LeagueClientUxRender.exe
 ; List of processes (comma separated) that AltSnap will not interfere with
 
 Windows=Program Manager|Progman,*|MultitaskingViewFrame,Volume Control|Tray Volume,*|TaskSwitcherWnd,*|TaskSwitcherOverlayWnd,|WorkerW,|Shell_TrayWnd,|BaseBar,|#32768,*|XamlExplorerHostIslandWindow,|MozillaDropShadowWindowClass,*|VistaSwitcher_SwitcherWnd,|TaskListThumbnailWnd,|NotifyIconOverflowWindow,*|Windows.UI.Core.CoreWindow,|NativeHWNDHost,*|Xaml_WindowedPopupClass,|Shell_SecondaryTrayWnd,*|SimpleWindowSwitcher_{BEA057BB-66C7-4758-A610-FAE6013E9F98},yui.exe:Yui|YuiWnd


### PR DESCRIPTION
The blacklist contains the following:
LeageClient.exe,LeageClientUx.exe,LeageClientUxRender.exe

Every time, "League" is misspelled as "Leage". That could be why it has no effect.

_Originally posted by @AnsonX10 in https://github.com/RamonUnch/AltSnap/issues/533#issuecomment-3201612235_